### PR TITLE
Fix audio header padding

### DIFF
--- a/PyCriCodecs/usm.py
+++ b/PyCriCodecs/usm.py
@@ -923,8 +923,7 @@ class USMBuilder:
                         0,
                         0
                     )
-                    chk += metadata
-                    chk.ljust(len(metadata) + padding, b"\x00")
+                    chk += metadata.ljust(len(metadata) + padding, b"\x00")
                     audio_metadata.append(chk)
                     chno += 1
 


### PR DESCRIPTION
Audio header padding is now correctly applied.

Without the change taking an existing USM with VP9 + HCA and simply extracting and rebuilding would yield a USM that would throw an error when calling `get_metadata()`. With the change the same process yields a successfully parsed USM. This also gets audio playing in game instead of hanging on a black screen.